### PR TITLE
Update update.sh

### DIFF
--- a/Update.sh
+++ b/Update.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Update PoshC2
 echo ""
@@ -15,19 +15,26 @@ echo ""
 echo "[+] Updating PoshC2_Python"
 echo ""
 
+ROOTDIR=`dirname "$0"`
+if [ ! -d "$ROOTDIR" ]; then
+  ROOTDIR="/opt/PoshC2_Python/"
+fi
+pushd "$ROOTDIR" > /dev/null
+
 # Backup config
-echo "[+] Backup Config.py"
-mv /opt/PoshC2_Python/Config.py /tmp/Config.py
+echo "[+] Backup Config"
+git stash > /dev/null
 
 # Install requirements for PoshC2_Python
 echo ""
-echo "[+] Performing git pull on /opt/PoshC2_Python/"
-cd /opt/PoshC2_Python/
-git pull
+echo "[+] Performing git pull on $ROOTDIR"
+git pull 
 
 # Restore config
-echo "[+] Restore Config.py"
-mv /tmp/Config.py /opt/PoshC2_Python/Config.py
+echo "[+] Restore Config"
+git stash pop > /dev/null
 echo ""
 echo "[+] Update complete"
 echo ""
+
+popd > /dev/null


### PR DESCRIPTION
The update script presently doesn't work if your **.gitconfig** is set to rebase by default, as it fails saying that there are unstaged changes as the **Config.py** has been moved.

This change alters the following:

-  Use `git stash` to store all changes (in case more than **Config.py** has been changed) before the pull.
- `pushd` to change to the working directory of the **Update.sh** script, so that the script can be run from anywhere and does not depend on the **ROOTDIR** being **/opt/PoshC2_Python**.
- `popd` after the pull to restore the prompt to the directory that the user was in before they ran the script.

**Note that `pushd` and `popd` aren't in `sh` so I've changed the shebang to `#!/bin/bash`, if this is breaking change I can undo it/work around it but it was the most straightforward solution.**