### PR TITLE
Add TLSv1 configuration option

### DIFF
--- a/C2Server.py
+++ b/C2Server.py
@@ -324,12 +324,13 @@ if __name__ == '__main__':
     print (Colours.END)
 
     if (os.path.isfile("%sposh.crt" % ROOTDIR)) and (os.path.isfile("%sposh.key" % ROOTDIR)):
-      try:
-        httpd.socket = ssl.wrap_socket (httpd.socket, keyfile="%sposh.key" % ROOTDIR, certfile="%sposh.crt" % ROOTDIR, server_side=True, ssl_version=ssl.PROTOCOL_TLS)
-      except Exception as e:
-        httpd.socket = ssl.wrap_socket (httpd.socket, keyfile="%sposh.key" % ROOTDIR, certfile="%sposh.crt" % ROOTDIR, server_side=True, ssl_version=ssl.PROTOCOL_TLSv1)
-        # add this if required - https://github.com/nettitude/PoshC2_Python/issues/13
-        # httpd.socket = ssl.wrap_socket (httpd.socket, keyfile="%sposh.key" % ROOTDIR, certfile="%sposh.crt" % ROOTDIR, server_side=True, ssl_version=ssl.PROTOCOL_TLSv1)
+      if UseTLSv1:
+          httpd.socket = ssl.wrap_socket (httpd.socket, keyfile="%sposh.key" % ROOTDIR, certfile="%sposh.crt" % ROOTDIR, server_side=True, ssl_version=ssl.PROTOCOL_TLSv1)
+      else:
+        try:
+          httpd.socket = ssl.wrap_socket (httpd.socket, keyfile="%sposh.key" % ROOTDIR, certfile="%sposh.crt" % ROOTDIR, server_side=True, ssl_version=ssl.PROTOCOL_TLS)
+        except Exception as e:
+          httpd.socket = ssl.wrap_socket (httpd.socket, keyfile="%sposh.key" % ROOTDIR, certfile="%sposh.crt" % ROOTDIR, server_side=True, ssl_version=ssl.PROTOCOL_TLSv1)
 
     else:
       raise ValueError("Cannot find the certificate files")

--- a/Config.py
+++ b/Config.py
@@ -46,7 +46,7 @@ HTTPResponses = [
 ]
 ServerHeader = "Apache"
 Insecure = "[System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}"
-
+UseTLSv1 = False
 
 
 # DO NOT CHANGE #


### PR DESCRIPTION
Add a `UseTLSv1` option to `Config.py` which is set to `False` by default. If set to `True`, a TLSv1 socket connection is used by the server.

I left the server side fallback to TLSv1 in place in case they fixes any other issues, but removed the comment about the GitHub Issue as it would no longer be necessary.