### PR TITLE
Implant names

### DIFF
--- a/DB.py
+++ b/DB.py
@@ -23,7 +23,8 @@ def initializedb():
         Alive TEXT,
         Sleep TEXT,
         ModsLoaded TEXT,
-        Pivot TEXT);"""
+        Pivot TEXT,
+        Label TEXT);"""
 
   create_autoruns = """CREATE TABLE AutoRuns (
         TaskID INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE,
@@ -283,6 +284,12 @@ def update_sleep( sleep, randomuri ):
   c.execute("UPDATE Implants SET Sleep=? WHERE RandomURI=?",(sleep, randomuri))
   conn.commit()
 
+def update_label( label, randomuri ):
+  conn = sqlite3.connect(DB)
+  c = conn.cursor()
+  c.execute("UPDATE Implants SET Label=? WHERE RandomURI=?",(label, randomuri))
+  conn.commit()
+
 def update_mods( modules, randomuri ):
   conn = sqlite3.connect(DB)
   c = conn.cursor()
@@ -351,11 +358,11 @@ def update_implant_lastseen(time, randomuri):
   c.execute("UPDATE Implants SET LastSeen=? WHERE RandomURI=?", (time,randomuri))
   conn.commit()
 
-def new_implant(RandomURI, User, Hostname, IpAddress, Key, FirstSeen, LastSeen, PID, Proxy, Arch, Domain, Alive, Sleep, ModsLoaded, Pivot):
+def new_implant(RandomURI, User, Hostname, IpAddress, Key, FirstSeen, LastSeen, PID, Proxy, Arch, Domain, Alive, Sleep, ModsLoaded, Pivot, Label):
   conn = sqlite3.connect(DB)
   conn.row_factory = sqlite3.Row
   c = conn.cursor()
-  c.execute("INSERT INTO Implants (RandomURI, User, Hostname, IpAddress, Key, FirstSeen, LastSeen, PID, Proxy, Arch, Domain, Alive, Sleep, ModsLoaded, Pivot) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", (RandomURI, User, Hostname, IpAddress, Key, FirstSeen, LastSeen, PID, Proxy, Arch, Domain, Alive, Sleep, ModsLoaded, Pivot))
+  c.execute("INSERT INTO Implants (RandomURI, User, Hostname, IpAddress, Key, FirstSeen, LastSeen, PID, Proxy, Arch, Domain, Alive, Sleep, ModsLoaded, Pivot, Label) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", (RandomURI, User, Hostname, IpAddress, Key, FirstSeen, LastSeen, PID, Proxy, Arch, Domain, Alive, Sleep, ModsLoaded, Pivot, Label))
   conn.commit()
 
 def insert_completedtask(randomuri, command, output, prompt):

--- a/HTML.py
+++ b/HTML.py
@@ -209,7 +209,7 @@ function SearchTask() {
 function tweakMarkup(){
   
   // Add classes to columns
-  var classes = ['id', 'taskid', 'randomuri', 'command', 'output', 'prompt','ImplantID','RandomURI','User','Hostname','IpAddress','Key','FirstSeen','LastSeen','PID','Proxy','Arch','Domain','Alive','Sleep','ModsLoaded','Pivot']
+  var classes = ['id', 'Label', taskid', 'randomuri', 'command', 'output', 'prompt','ImplantID','RandomURI','User','Hostname','IpAddress','Key','FirstSeen','LastSeen','PID','Proxy','Arch','Domain','Alive','Sleep','ModsLoaded','Pivot']
   tbl = document.getElementById("PoshTable");
   ths = tbl.getElementsByTagName("th");
   for( i=0; i<ths.length; i++ ){
@@ -228,7 +228,7 @@ function tweakMarkup(){
     for( j=0; j<tds.length; j++ ){
       td = tds[j];
       td.className = classes[j]
-      if( td.className.match(/output|Hostname|IpAddress|Key|FirstSeen|LastSeen|PID|Proxy|Arch|Domain|Alive|Sleep|ModsLoaded|Pivot|id|taskid|randomuri|command|output|prompt|ImplantID|RandomURI|User|Hostname|IpAddress|Key|FirstSeen|LastSeen|PID|Proxy|Arch|Domain|Alive|Sleep|ModsLoaded|Pivot/) ){
+      if( td.className.match(/output|Hostname|IpAddress|Key|FirstSeen|LastSeen|PID|Proxy|Arch|Domain|Alive|Sleep|ModsLoaded|Pivot|id|Label|taskid|randomuri|command|output|prompt|ImplantID|RandomURI|User|Hostname|IpAddress|Key|FirstSeen|LastSeen|PID|Proxy|Arch|Domain|Alive|Sleep|ModsLoaded|Pivot/) ){
         td.className += ' hidden';
         td.innerHTML = '<div>' + td.innerHTML + '</div>';
         td.onclick = toggleHide
@@ -398,6 +398,7 @@ __________            .__.     _________  ________
   HTMLPost = HTMLPost.replace("<table border=\"1\" class=\"dataframe table\">","<table id=\"PoshTable\" border=\"1\" class=\"PoshTableClass\">")
   HTMLPost = HTMLPost.replace("<th>CompletedTaskID</th>","<th class=\"CompletedTaskID\">ID</th>")
   HTMLPost = HTMLPost.replace("<th>ID</th>","<th class=\"ID\">ID</th>")
+  HTMLPost = HTMLPost.replace("<th>Label</th>","<th class=\"Label\">Label</th>")
   HTMLPost = HTMLPost.replace("<th>TaskID</th>","<th class=\"TaskID\">TaskID</th>")
   HTMLPost = HTMLPost.replace("<th>RandomURI</th>","<th class=\"RandomURI\">RandomURI</th>")
   HTMLPost = HTMLPost.replace("<th>Command</th>","<th class=\"Command\">Command</th>")

--- a/Help.py
+++ b/Help.py
@@ -32,6 +32,7 @@ unhide-implant
 help
 searchhelp mimikatz
 back
+label-implant
 """
 
 sharp_help1 = """
@@ -397,7 +398,7 @@ COMMANDS = ['loadmodule',"bloodhound","brute-ad","brute-locadmin",
 "get-system-withproxy","get-system-withdaisy","get-pid","listmodules","modulesloaded",
 "startanotherimplant","remove-persistence","removeexe-persistence","installexe-persistence",
 "get-hash","get-creds","resolve-ipaddress","invoke-wmievent","remove-wmievent","get-wmievent",
-"invoke-smbclient","get-keystrokedata","unhidefile","hidefile"]
+"invoke-smbclient","get-keystrokedata","unhidefile","hidefile", "label-implant"]
 
 COMMANDS += ['invoke-psexecpayload','invoke-wmipayload', 'invoke-dcompayload']
 COMMANDS += ['invoke-psexecproxypayload','invoke-wmiproxypayload', 'invoke-dcomproxypayload']

--- a/Implant.py
+++ b/Implant.py
@@ -11,6 +11,7 @@ class Implant(object):
 
   def __init__(self, ipaddress, pivot, domain, user, hostname, arch, pid, proxy):
     self.RandomURI = randomuri()
+    self.Label = None
     self.User = user
     self.Hostname = hostname
     self.IPAddress = ipaddress
@@ -588,7 +589,7 @@ while($true)
       print "SMS send error: %s" % e
       
   def save(self):
-    new_implant(self.RandomURI, self.User, self.Hostname, self.IPAddress, self.Key, self.FirstSeen, self.FirstSeen, self.PID, self.Proxy, self.Arch, self.Domain, self.Alive, self.Sleep, self.ModsLoaded, self.Pivot)
+    new_implant(self.RandomURI, self.User, self.Hostname, self.IPAddress, self.Key, self.FirstSeen, self.FirstSeen, self.PID, self.Proxy, self.Arch, self.Domain, self.Alive, self.Sleep, self.ModsLoaded, self.Pivot, self.Label)
 
   def autoruns(self):
     new_task("loadmodule Implant-Core.ps1", self.RandomURI)

--- a/ImplantHandler.py
+++ b/ImplantHandler.py
@@ -176,6 +176,7 @@ def startup(printhelp = ""):
         PID = i[8]
         Pivot = i[15]
         Sleep = i[13]
+        Label = i[16]
         if Pivot == "Daisy": Pivot = "D"
         elif Pivot == "C#": Pivot = "C#"
         elif Pivot == "Proxy": Pivot = "P"
@@ -188,12 +189,16 @@ def startup(printhelp = ""):
         nowplus10 = now - timedelta(minutes=10)
         nowplus60 = now - timedelta(minutes=59)
         sID = "["+str(ID)+"]"
-        if nowplus60 > LastSeenTime:
-          print (Colours.RED + "%s: Seen:%s | PID:%s | %s | %s @ %s (%s) %s" % (sID.ljust(4), LastSeen, PID.ljust(5), Sleep, DomainUser, Hostname, Arch, Pivot))
-        elif nowplus10 > LastSeenTime:
-          print (Colours.YELLOW + "%s: Seen:%s | PID:%s | %s | %s @ %s (%s) %s" % (sID.ljust(4), LastSeen, PID.ljust(5), Sleep, DomainUser, Hostname, Arch, Pivot))
+        if Label == None:
+          sLabel = ""
         else:
-          print (Colours.GREEN + "%s: Seen:%s | PID:%s | %s | %s @ %s (%s) %s" % (sID.ljust(4), LastSeen, PID.ljust(5), Sleep, DomainUser, Hostname, Arch, Pivot))
+          sLabel = "["+Label+"]"
+        if nowplus60 > LastSeenTime:
+          print (Colours.RED + "%s%s: Seen:%s | PID:%s | %s | %s @ %s (%s) %s" % (sID.ljust(4), sLabel, LastSeen, PID.ljust(5), Sleep, DomainUser, Hostname, Arch, Pivot))
+        elif nowplus10 > LastSeenTime:
+          print (Colours.YELLOW + "%s%s: Seen:%s | PID:%s | %s | %s @ %s (%s) %s" % (sID.ljust(4), sLabel, LastSeen, PID.ljust(5), Sleep, DomainUser, Hostname, Arch, Pivot))
+        else:
+          print (Colours.GREEN + "%s%s: Seen:%s | PID:%s | %s | %s @ %s (%s) %s" % (sID.ljust(4), sLabel, LastSeen, PID.ljust(5), Sleep, DomainUser, Hostname, Arch, Pivot))
     else:
       from datetime import datetime, timedelta
       now = datetime.now()
@@ -416,6 +421,11 @@ def runcommand(command, randomuri):
       sleep = '$sleeptime = %s' % command
       update_sleep(command, randomuri)
       new_task(sleep, randomuri)
+
+    elif (command.lower().startswith('label-implant')):
+        label = command.replace('label-implant ', '')
+        update_label(label, randomuri)
+        startup()
 
     elif "searchhelp" in command.lower():
       searchterm = (command.lower()).replace("searchhelp ","")
@@ -646,6 +656,11 @@ def runcommand(command, randomuri):
         command = command.replace('setbeacon ', '')
         command = command.replace('beacon ', '')
         update_sleep(command, randomuri)
+
+      elif (command.lower().startswith('label-implant')):
+        label = command.replace('label-implant ', '')
+        update_label(label, randomuri)
+        startup()
             
       else:
         if command:
@@ -666,6 +681,11 @@ def runcommand(command, randomuri):
       command = command.replace('setbeacon ', '')
       command = command.replace('beacon ', '')
       update_sleep(command, randomuri)
+
+    elif (command.lower().startswith('label-implant')):
+        label = command.replace('label-implant ', '')
+        update_label(label, randomuri)
+        startup()
 
     elif "searchhelp" in command.lower():
       searchterm = (command.lower()).replace("searchhelp ","")

--- a/OfflineReportGenerator.py
+++ b/OfflineReportGenerator.py
@@ -204,7 +204,7 @@ function SearchTask() {
 function tweakMarkup(){
 
   // Add classes to columns
-  var classes = ['id', 'taskid', 'randomuri', 'command', 'output', 'prompt','ImplantID','RandomURI','User','Hostname','IpAddress','Key','FirstSeen','LastSeen','PID','Proxy','Arch','Domain','Alive','Sleep','ModsLoaded','Pivot']
+  var classes = ['id', 'Label', taskid', 'randomuri', 'command', 'output', 'prompt','ImplantID','RandomURI','User','Hostname','IpAddress','Key','FirstSeen','LastSeen','PID','Proxy','Arch','Domain','Alive','Sleep','ModsLoaded','Pivot']
   tbl = document.getElementById("PoshTable");
   ths = tbl.getElementsByTagName("th");
   for( i=0; i<ths.length; i++ ){
@@ -223,7 +223,7 @@ function tweakMarkup(){
     for( j=0; j<tds.length; j++ ){
       td = tds[j];
       td.className = classes[j]
-      if( td.className.match(/output|Hostname|IpAddress|Key|FirstSeen|LastSeen|PID|Proxy|Arch|Domain|Alive|Sleep|ModsLoaded|Pivot|id|taskid|randomuri|command|output|prompt|ImplantID|RandomURI|User|Hostname|IpAddress|Key|FirstSeen|LastSeen|PID|Proxy|Arch|Domain|Alive|Sleep|ModsLoaded|Pivot/) ){
+      if( td.className.match(/output|Hostname|IpAddress|Key|FirstSeen|LastSeen|PID|Proxy|Arch|Domain|Alive|Sleep|ModsLoaded|Pivot|id|taskid|randomuri|command|output|prompt|ImplantID|RandomURI|User|Hostname|IpAddress|Key|FirstSeen|LastSeen|PID|Proxy|Arch|Domain|Alive|Sleep|ModsLoaded|Pivot|Label/) ){
         td.className += ' hidden';
         td.innerHTML = '<div>' + td.innerHTML + '</div>';
         td.onclick = toggleHide
@@ -393,6 +393,7 @@ __________            .__.     _________  ________
   HTMLPost = HTMLPost.replace("<table border=\"1\" class=\"dataframe table\">","<table id=\"PoshTable\" border=\"1\" class=\"PoshTableClass\">")
   HTMLPost = HTMLPost.replace("<th>CompletedTaskID</th>","<th class=\"CompletedTaskID\">ID</th>")
   HTMLPost = HTMLPost.replace("<th>ID</th>","<th class=\"ID\">ID</th>")
+  HTMLPost = HTMLPost.replace("<th>Label</th>","<th class=\"Label\">Label</th>")
   HTMLPost = HTMLPost.replace("<th>TaskID</th>","<th class=\"TaskID\">TaskID</th>")
   HTMLPost = HTMLPost.replace("<th>RandomURI</th>","<th class=\"RandomURI\">RandomURI</th>")
   HTMLPost = HTMLPost.replace("<th>Command</th>","<th class=\"Command\">Command</th>")


### PR DESCRIPTION
~~Added an Implant Name/Label option.~~ Updated, see second comment below.

I've found that when I have multiple implants it can be confusing to determine which one is which, e.g. if I have a PS implant and one staged from the dll for the same host, so this adds a label after the ID in the ImplantHandler output.

~~The label is random to begin with, but can be renamed with `rename-implant`. This will check to see if an implant with that name already exists, and if so will not rename it (similarly it will check when a random name is assigned on creation). Uniqueness is enforced for clarity but also as potentially in the future we could add the ability to interact with the Implant via it's name as well as its ID (but this is not included at present as it felt like too big a change).~~

~~The command has been added to the autocomplete and HTML generation, though I'm still tweaking the latter but figured I'd get your eyes on this.~~

Open to suggestions/edits of course!

<img width="681" alt="implant_handler_with_names" src="https://user-images.githubusercontent.com/20513519/50560950-ca315280-0cfd-11e9-9511-22483cd786b3.png">
<img width="689" alt="rename_implant" src="https://user-images.githubusercontent.com/20513519/50560951-ca315280-0cfd-11e9-8d39-5ecdd5555099.png">
<img width="690" alt="name_already_exists" src="https://user-images.githubusercontent.com/20513519/50560952-cac9e900-0cfd-11e9-844a-dc7037dd5bde.png">

